### PR TITLE
make build a release type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,11 @@ set(ROOT_DIR ${PROJECT_SOURCE_DIR})
 
 if(UNIX)
 	#linux
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -ggdb -fPIC")
+	
 	if(CMAKE_BUILD_TYPE MATCHES "debug")
 		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -fPIC")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -D_DEBUG")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -ggdb -fPIC")
 	else()
 		set(CMAKE_BUILD_TYPE "Release")
 		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -fPIC")


### PR DESCRIPTION
在主目录下编译的时候，不要默认添加 CMAKE_CXX_FLAGS -Wall -g -ggdb -fPIC 选项，只在 Debug 模式下才加。